### PR TITLE
Removing unnecessary"await"

### DIFF
--- a/src/app/modules/wallet/hooks/useWalletAuth.tsx
+++ b/src/app/modules/wallet/hooks/useWalletAuth.tsx
@@ -51,7 +51,7 @@ export function useWalletAuth() {
         await instance.connect(localStorageAddress);
       } else {
         await instance.connect();
-        const walletAddress = await instance.getAddress();
+        const walletAddress = instance.getAddress();
         window.localStorage.setItem("walletAddress", walletAddress);
       }
 


### PR DESCRIPTION
Useless "await" on  instance.getAddress() method call Line 54